### PR TITLE
Fix pgsql layer to work with the reactive installed by charm-tools.

### DIFF
--- a/provides.py
+++ b/provides.py
@@ -12,10 +12,10 @@
 # limitations under the License.
 
 from charmhelpers.core import hookenv
-from charmhelpers.core.reactive import RelationBase
-from charmhelpers.core.reactive import scopes
-from charmhelpers.core.reactive import hook
-from charmhelpers.core.reactive import not_until
+from charms.reactive import RelationBase
+from charms.reactive import scopes
+from charms.reactive import hook
+from charms.reactive import not_until
 
 
 class PostgreSQL(RelationBase):

--- a/requires.py
+++ b/requires.py
@@ -11,9 +11,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from charmhelpers.core.reactive import RelationBase
-from charmhelpers.core.reactive import hook
-from charmhelpers.core.reactive import scopes
+from charms.reactive import RelationBase
+from charms.reactive import hook
+from charms.reactive import scopes
 
 
 class PostgreSQLClient(RelationBase):


### PR DESCRIPTION
The interface:pgsql layer is out of date with the version of reactive that gets installed by `charm compose` (installed from ppa:juju/stable). This updates the module imports to match.
